### PR TITLE
[Chore] Place 도메인, Reservation 도메인 엔티티 구현

### DIFF
--- a/src/main/java/com/moti/backend/BackendApplication.java
+++ b/src/main/java/com/moti/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package com.moti.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/com/moti/backend/core/place/domain/entity/Place.java
+++ b/src/main/java/com/moti/backend/core/place/domain/entity/Place.java
@@ -2,8 +2,6 @@ package com.moti.backend.core.place.domain.entity;
 
 import com.moti.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,8 +11,6 @@ import static lombok.AccessLevel.*;
 @Table(name = "place")
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-@AllArgsConstructor(access = PRIVATE)
-@Builder
 public class Place extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/moti/backend/core/place/domain/entity/Place.java
+++ b/src/main/java/com/moti/backend/core/place/domain/entity/Place.java
@@ -1,0 +1,31 @@
+package com.moti.backend.core.place.domain.entity;
+
+import com.moti.backend.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.*;
+
+@Entity
+@Table(name = "place")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
+@Builder
+public class Place extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "address", nullable = false)
+    private String address;
+
+    @Column(name = "seat_count", nullable = false)
+    private int seatCount;
+}

--- a/src/main/java/com/moti/backend/core/place/domain/entity/Seat.java
+++ b/src/main/java/com/moti/backend/core/place/domain/entity/Seat.java
@@ -1,0 +1,33 @@
+package com.moti.backend.core.place.domain.entity;
+
+import com.moti.backend.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "seat")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
+@Builder
+public class Seat extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "zone_id", nullable = false)
+    private Zone zone;
+
+    @Column(name = "row", nullable = false)
+    private int row;
+
+    @Column(name = "column", nullable = false)
+    private int column;
+}

--- a/src/main/java/com/moti/backend/core/place/domain/entity/Seat.java
+++ b/src/main/java/com/moti/backend/core/place/domain/entity/Seat.java
@@ -2,20 +2,15 @@ package com.moti.backend.core.place.domain.entity;
 
 import com.moti.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Table(name = "seat")
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-@AllArgsConstructor(access = PRIVATE)
-@Builder
 public class Seat extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,4 +25,7 @@ public class Seat extends BaseTimeEntity {
 
     @Column(name = "column", nullable = false)
     private int column;
+
+    @Column(name = "status", nullable = false)
+    private boolean status;
 }

--- a/src/main/java/com/moti/backend/core/place/domain/entity/Zone.java
+++ b/src/main/java/com/moti/backend/core/place/domain/entity/Zone.java
@@ -8,8 +8,6 @@ import lombok.*;
 @Table(name = "zone")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
 public class Zone extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/moti/backend/core/place/domain/entity/Zone.java
+++ b/src/main/java/com/moti/backend/core/place/domain/entity/Zone.java
@@ -1,0 +1,24 @@
+package com.moti.backend.core.place.domain.entity;
+
+import com.moti.backend.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "zone")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Zone extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id", nullable = false)
+    private Place place;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+}

--- a/src/main/java/com/moti/backend/core/reservation/domain/entity/Reservation.java
+++ b/src/main/java/com/moti/backend/core/reservation/domain/entity/Reservation.java
@@ -1,0 +1,39 @@
+package com.moti.backend.core.reservation.domain.entity;
+
+import com.moti.backend.core.reservation.domain.type.ReservationStatus;
+import com.moti.backend.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "reservation")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
+@Builder
+public class Reservation extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "show_seat_mapping_id", nullable = false)
+    private ShowSeatMapping showSeatMapping;
+
+//    @ManyToOne(fetch = LAZY)
+//    @JoinColumn(name = "member_id", nullable = false)
+//    private Member member
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ReservationStatus status;
+}
+

--- a/src/main/java/com/moti/backend/core/reservation/domain/entity/Reservation.java
+++ b/src/main/java/com/moti/backend/core/reservation/domain/entity/Reservation.java
@@ -3,21 +3,16 @@ package com.moti.backend.core.reservation.domain.entity;
 import com.moti.backend.core.reservation.domain.type.ReservationStatus;
 import com.moti.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static jakarta.persistence.FetchType.LAZY;
-import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Table(name = "reservation")
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-@AllArgsConstructor(access = PRIVATE)
-@Builder
 public class Reservation extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/moti/backend/core/reservation/domain/entity/ShowSeatMapping.java
+++ b/src/main/java/com/moti/backend/core/reservation/domain/entity/ShowSeatMapping.java
@@ -1,0 +1,42 @@
+package com.moti.backend.core.reservation.domain.entity;
+
+import com.moti.backend.core.place.domain.entity.Seat;
+import com.moti.backend.core.reservation.domain.type.SeatStatus;
+import com.moti.backend.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "show_seat_mapping")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
+@Builder
+public class ShowSeatMapping extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "show_schedule_id", nullable = false)
+    private Long showScheduleId;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "seat_id", nullable = false)
+    private Seat seat;
+
+//    @ManyToOne(fetch = LAZY)
+//    @JoinColumn(name = "grade_id", nullable = false)
+//    private Grade grade;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private SeatStatus status;
+}

--- a/src/main/java/com/moti/backend/core/reservation/domain/entity/ShowSeatMapping.java
+++ b/src/main/java/com/moti/backend/core/reservation/domain/entity/ShowSeatMapping.java
@@ -4,21 +4,16 @@ import com.moti.backend.core.place.domain.entity.Seat;
 import com.moti.backend.core.reservation.domain.type.SeatStatus;
 import com.moti.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static jakarta.persistence.FetchType.LAZY;
-import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Table(name = "show_seat_mapping")
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-@AllArgsConstructor(access = PRIVATE)
-@Builder
 public class ShowSeatMapping extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/moti/backend/core/reservation/domain/type/ReservationStatus.java
+++ b/src/main/java/com/moti/backend/core/reservation/domain/type/ReservationStatus.java
@@ -1,0 +1,7 @@
+package com.moti.backend.core.reservation.domain.type;
+
+public enum ReservationStatus {
+    CONFIRMED,
+    CANCELLED,
+    PENDING
+}

--- a/src/main/java/com/moti/backend/core/reservation/domain/type/SeatStatus.java
+++ b/src/main/java/com/moti/backend/core/reservation/domain/type/SeatStatus.java
@@ -1,0 +1,7 @@
+package com.moti.backend.core.reservation.domain.type;
+
+public enum SeatStatus {
+    AVAILABLE,
+    RESERVED,
+    HOLD
+}

--- a/src/main/java/com/moti/backend/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/moti/backend/global/entity/BaseTimeEntity.java
@@ -1,0 +1,19 @@
+package com.moti.backend.global.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}


### PR DESCRIPTION
## 연관된 이슈
> #7 

## 작업 내용
- Place, Zone, Seat 관련 JPA 엔티티 설계 및 구현
- BaseTimeEntity 상속을 통한 공통 생성일/수정일 컬럼 처리
- new 기반 객체 생성 방식 채택

### Place 엔티티
```java
@Entity
@Table(name = "place")
@Getter
@NoArgsConstructor(access = PROTECTED)
public class Place extends BaseTimeEntity {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @Column(name = "name", nullable = false)
    private String name;

    @Column(name = "address", nullable = false)
    private String address;

    @Column(name = "seat_count", nullable = false)
    private int seatCount;
}

```
### Zone 엔티티
```java
@Entity
@Table(name = "zone")
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class Zone extends BaseTimeEntity {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "place_id", nullable = false)
    private Place place;

    @Column(name = "name", nullable = false)
    private String name;
}

```
### Seat 엔티티
```java
@Entity
@Table(name = "seat")
@Getter
@NoArgsConstructor(access = PROTECTED)
public class Seat extends BaseTimeEntity {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "zone_id", nullable = false)
    private Zone zone;

    @Column(name = "row", nullable = false)
    private int row;

    @Column(name = "column", nullable = false)
    private int column;
}
```
### Builder 패턴을 사용한 엔티티 생성을 선택한 이유
기본적으로 모든 엔티티는 불변성과 객체 생성 간에 Builder 패턴을 통한 명시적인 생성을 하기 위해서 위와 같이 어노테이션을 사용하였습니다.
- @AllArgsContructor
- @Builder  
 
만일 new Place(.. 파라미터) 기법을 선호하신다면 리뷰 때 코멘트를 붙여주세요 의견을 나눠보면 좋을 것 같습니다:) 
### 회의 이후 new 패턴을 사용한 엔티티 생성으로 수정
- 현재 프로젝트의 크기에 따라 엔티티 생성이 Builder로 구현되어도 이점이 없다고 판단하여 우선은 new 객체 생성하게 변경

### ManyToOne만 사용한 이유  
조회 API 사용 시에 트리 형태의 탐색이 필요할 것 같습니다. 그렇기에 OneToMany도 적절한 것 같지만 선택하지않은 이유는 아래와 같습니다.  
이번 PR에서는 Place, Zone, Seat 간의 연관관계를 단방향 @ManyToOne 중심으로 구성했습니다. 그 이유는 다음과 같습니다.  

1. 연관관계의 주인은 ManyToOne이기 때문입니다.  
JPA에서 실제로 외래키를 관리하는 쪽은 @ManyToOne입니다.  
즉, Seat → Zone, Zone → Place 구조에서 하위 엔티티가 상위 엔티티를 참조함으로써 연관관계의 주인을 명확하게 설정할 수 있습니다.  
이는 DDL 생성 시 외래키가 올바르게 반영되고, 데이터 변경 시 JPA가 연관관계를 일관되게 관리할 수 있게 해줍니다.  

2. 단방향 관계로 순환 참조를 방지했습니다.  
@OneToMany를 포함한 양방향 관계는 설계가 복잡해지고, 객체 순환에 따른 JSON 직렬화 이슈 또는 StackOverflow와 같은 런타임 에러의 가능성이 높아집니다.  
이번 설계에서는 하위 → 상위 방향으로만 참조가 존재하므로, 직렬화 및 테스트, 쿼리 최적화 측면에서 안정성을 확보할 수 있습니다.  

3. 필요한 경우 쿼리로 명시적으로 탐색할 수 있습니다.  
조회 API에서 특정 장소의 구역 및 좌석을 계층 구조로 구성해야 할 경우, 명시적인 JPQL 또는 QueryDSL을 사용하여 JOIN 기반으로 데이터를 탐색할 수 있습니다.  
이 방식은 객체 그래프 탐색에 의존하지 않기 때문에 쿼리 최적화와 성능 제어가 훨씬 용이합니다.  

4. 불필요한 컬렉션 로딩을 방지할 수 있습니다.  
@OneToMany 관계는 의도하지 않은 컬렉션 로딩을 유발하거나 Lazy 동작을 제대로 통제하기 어렵습니다.  
반면, 현재 구조는 모든 연관관계가 명시적으로 로딩되며, 필요한 데이터만 정확하게 조회할 수 있도록 설계되었습니다.  

다른 의견이 있으시다면 편하게 코멘트 남겨주세요:)  

### JPA 상속 기능을 활용한 Auditing 컬럼 관리
```java
@MappedSuperclass
@EntityListeners(AuditingEntityListener.class)
public abstract class BaseTimeEntity {
    @CreatedDate
    private LocalDateTime createdAt;

    @LastModifiedDate
    private LocalDateTime modifiedAt;
}
```
- 모든 엔티티에 BaseTimeEntity를 상속시켜 createdAt, modifiedAt 필드를 공통 처리했습니다.

### ShowSeatMapping 엔티티
```java
@Entity
@Table(name = "show_seat_mapping")
@Getter
@NoArgsConstructor(access = PROTECTED)
public class ShowSeatMapping extends BaseTimeEntity {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @Column(name = "show_schedule_id", nullable = false)
    private Long showScheduleId;

    @ManyToOne(fetch = LAZY)
    @JoinColumn(name = "seat_id", nullable = false)
    private Seat seat;

//    @ManyToOne(fetch = LAZY)
//    @JoinColumn(name = "grade_id", nullable = false)
//    private Grade grade;

    @Enumerated(EnumType.STRING)
    @Column(name = "status", nullable = false)
    private SeatStatus status;
}
```
- 주석 처리로 추후에 생성될 외래키를 설정해주었습니다.

### Reservation 엔티티
```java
@Entity
@Table(name = "reservation")
@Getter
@NoArgsConstructor(access = PROTECTED)
public class Reservation extends BaseTimeEntity {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @ManyToOne(fetch = LAZY)
    @JoinColumn(name = "show_seat_mapping_id", nullable = false)
    private ShowSeatMapping showSeatMapping;

//    @ManyToOne(fetch = LAZY)
//    @JoinColumn(name = "member_id", nullable = false)
//    private Member member

    @Enumerated(EnumType.STRING)
    @Column(name = "status", nullable = false)
    private ReservationStatus status;
}
```
- 주석 처리로 추후에 생성될 외래키를 설정해주었습니다.

## 테스트 결과
> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등
- 실행해보고 정상적으로 테이블이 생성되는 것을 확인했습니다:)

## 변경 사항 체크리스트
- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 리뷰 요구사항(선택)
- ~Builder 패턴을 활용한 명시적인 엔티티 생성 기법에 대한 의견이 필요합니다.~
- ~seat 테이블의 예매 상태 컬럼이 show_seat_mapping 테이블의 status 컬럼과 중복되는 것 같습니다.~
  - seat 테이블의 status는 물리적인 좌석의 상태를 나타내는 논리적 개념을 가진 필드 값으로 변경

## 참고 자료 (선택)
> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요