### PR TITLE
[Feat] 전체 공연 조회 api 구현

### DIFF
--- a/seed/1_show_seed.sql
+++ b/seed/1_show_seed.sql
@@ -1,0 +1,63 @@
+-- 기존 공연 데이터 안전 삭제
+DELETE FROM `show` WHERE id > 0;
+
+-- 기존 장소 데이터 안전 삭제 (외래키 제약조건 순서 고려)
+DELETE FROM seat WHERE id > 0;
+DELETE FROM zone WHERE id > 0;
+DELETE FROM place WHERE id > 0;
+
+-- AUTO_INCREMENT 초기화
+ALTER TABLE `show` AUTO_INCREMENT = 1;
+ALTER TABLE seat AUTO_INCREMENT = 1;
+ALTER TABLE zone AUTO_INCREMENT = 1;
+ALTER TABLE place AUTO_INCREMENT = 1;
+
+-- 장소 1개 생성
+INSERT INTO place (id, name, address, seat_count, created_at, modified_at) VALUES
+(1, 'Sample Place', '123 Sample Address', 18, NOW(), NOW());
+
+-- 구역 2개 생성
+INSERT INTO zone (id, place_id, name, created_at, modified_at) VALUES
+(1, 1, 'Zone A', NOW(), NOW()),
+(2, 1, 'Zone B', NOW(), NOW());
+
+-- Zone A 좌석 생성 (3행 x 3열 = 9좌석)
+INSERT INTO seat (id, zone_id, seat_row, seat_column, status, created_at, modified_at) VALUES
+(1, 1, 1, 1, TRUE, NOW(), NOW()),
+(2, 1, 1, 2, TRUE, NOW(), NOW()),
+(3, 1, 1, 3, TRUE, NOW(), NOW()),
+(4, 1, 2, 1, TRUE, NOW(), NOW()),
+(5, 1, 2, 2, TRUE, NOW(), NOW()),
+(6, 1, 2, 3, TRUE, NOW(), NOW()),
+(7, 1, 3, 1, TRUE, NOW(), NOW()),
+(8, 1, 3, 2, TRUE, NOW(), NOW()),
+(9, 1, 3, 3, TRUE, NOW(), NOW());
+
+-- Zone B 좌석 생성 (3행 x 3열 = 9좌석)
+INSERT INTO seat (id, zone_id, seat_row, seat_column, status, created_at, modified_at) VALUES
+(10, 2, 1, 1, TRUE, NOW(), NOW()),
+(11, 2, 1, 2, TRUE, NOW(), NOW()),
+(12, 2, 1, 3, TRUE, NOW(), NOW()),
+(13, 2, 2, 1, TRUE, NOW(), NOW()),
+(14, 2, 2, 2, TRUE, NOW(), NOW()),
+(15, 2, 2, 3, TRUE, NOW(), NOW()),
+(16, 2, 3, 1, TRUE, NOW(), NOW()),
+(17, 2, 3, 2, TRUE, NOW(), NOW()),
+(18, 2, 3, 3, TRUE, NOW(), NOW());
+
+-- 공연 5개 생성 (모두 동일한 장소 사용) - 관리자 제거버전
+INSERT INTO `show` (id, place_id, title, category, start_date, end_date, ticket_start_date_time, ticket_end_date_time, min_age, running_time_minute, intermission_time, show_img, created_at, modified_at) VALUES
+(1, 1, '공연 1', 'MUSICAL', '2025-07-01 00:00:00', '2025-07-10 23:59:59', '2025-06-20 14:00:00', '2025-06-30 23:59:59', 15, 120, 15, '/img/show1.png', NOW(), NOW()),
+(2, 1, '공연 2', 'MUSICAL', '2025-07-11 00:00:00', '2025-07-20 23:59:59', '2025-07-01 14:00:00', '2025-07-10 23:59:59', 12, 110, 10, '/img/show2.png', NOW(), NOW()),
+(3, 1, '공연 3', 'CONCERT', '2025-07-21 00:00:00', '2025-07-30 23:59:59', '2025-07-11 14:00:00', '2025-07-20 23:59:59', 18, 130, 20, '/img/show3.png', NOW(), NOW()),
+(4, 1, '공연 4', 'CONCERT', '2025-08-01 00:00:00', '2025-08-10 23:59:59', '2025-07-21 14:00:00', '2025-07-30 23:59:59', 10, 100, 5, '/img/show4.png', NOW(), NOW()),
+(5, 1, '공연 5', 'CONCERT', '2025-08-11 00:00:00', '2025-08-20 23:59:59', '2025-08-01 14:00:00', '2025-08-10 23:59:59', 20, 140, 25, '/img/show5.png', NOW(), NOW());
+
+
+-- -- 공연 5개 생성 (모두 동일한 장소 사용)
+-- INSERT INTO show (id, created_by, place_id, title, category, start_date, end_date, ticket_start_date_time, ticket_end_date_time, min_age, running_time_minute, intermission_time, show_img, created_at, modified_at) VALUES
+-- (1, 1, 1, '공연 1', 'MUSICAL', '2025-07-01 00:00:00', '2025-07-10 23:59:59', '2025-06-20 14:00:00', '2025-06-30 23:59:59', 15, 120, 15, '/img/show1.png', NOW(), NOW()),
+-- (2, 1, 1, '공연 2', 'MUSICAL', '2025-07-11 00:00:00', '2025-07-20 23:59:59', '2025-07-01 14:00:00', '2025-07-10 23:59:59', 12, 110, 10, '/img/show2.png', NOW(), NOW()),
+-- (3, 1, 1, '공연 3', 'CONCERT', '2025-07-21 00:00:00', '2025-07-30 23:59:59', '2025-07-11 14:00:00', '2025-07-20 23:59:59', 18, 130, 20, '/img/show3.png', NOW(), NOW()),
+-- (4, 1, 1, '공연 4', 'CONCERT', '2025-08-01 00:00:00', '2025-08-10 23:59:59', '2025-07-21 14:00:00', '2025-07-30 23:59:59', 10, 100, 5, '/img/show4.png', NOW(), NOW()),
+-- (5, 1, 1, '공연 5', 'CONCERT', '2025-08-11 00:00:00', '2025-08-20 23:59:59', '2025-08-01 14:00:00', '2025-08-10 23:59:59', 20, 140, 25, '/img/show5.png', NOW(), NOW());

--- a/src/main/java/com/moti/backend/core/show/application/ShowService.java
+++ b/src/main/java/com/moti/backend/core/show/application/ShowService.java
@@ -1,0 +1,18 @@
+package com.moti.backend.core.show.application;
+
+import org.springframework.stereotype.Service;
+
+import com.moti.backend.core.show.domain.service.ShowDomainService;
+import com.moti.backend.core.show.transfer.dto.ShowResponseDTO;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ShowService {
+	private final ShowDomainService showDomainService;
+
+	public ShowResponseDTO.InfoList getAllShows() {
+		return ShowResponseDTO.InfoList.from(showDomainService.findAllShows());
+	}
+}

--- a/src/main/java/com/moti/backend/core/show/domain/entity/Grade.java
+++ b/src/main/java/com/moti/backend/core/show/domain/entity/Grade.java
@@ -13,8 +13,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
 
 @Entity
+@Table(name = "grade")
+@Getter
 public class Grade extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/moti/backend/core/show/domain/entity/Grade.java
+++ b/src/main/java/com/moti/backend/core/show/domain/entity/Grade.java
@@ -1,0 +1,33 @@
+package com.moti.backend.core.show.domain.entity;
+
+import com.moti.backend.core.show.domain.type.SeatingTier;
+import com.moti.backend.global.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Grade extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private SeatingTier grade;
+
+	@Column(nullable = false)
+	private Integer price;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "show_id", nullable = false)
+	private Show show;
+}

--- a/src/main/java/com/moti/backend/core/show/domain/entity/Show.java
+++ b/src/main/java/com/moti/backend/core/show/domain/entity/Show.java
@@ -20,8 +20,8 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 
 @Entity
-@Getter
 @Table(name = "`show`")
+@Getter
 public class Show extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/moti/backend/core/show/domain/entity/Show.java
+++ b/src/main/java/com/moti/backend/core/show/domain/entity/Show.java
@@ -1,0 +1,67 @@
+package com.moti.backend.core.show.domain.entity;
+
+import java.time.LocalDateTime;
+
+import com.moti.backend.core.place.domain.entity.Place;
+import com.moti.backend.core.show.domain.type.Category;
+import com.moti.backend.global.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "`show`")
+public class Show extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Category category;
+
+	@Column(nullable = false)
+	private LocalDateTime startDate;
+
+	@Column(nullable = false)
+	private LocalDateTime endDate;
+
+	@Column(nullable = false)
+	private LocalDateTime ticketStartDateTime;
+
+	@Column(nullable = false)
+	private LocalDateTime ticketEndDateTime;
+
+	@Column(nullable = false)
+	private Integer minAge;
+
+	@Column(nullable = false)
+	private Integer runningTimeMinute;
+
+	@Column(nullable = false)
+	private Integer intermissionTime;
+
+	private String showImg;
+
+	// @ManyToOne(fetch = FetchType.LAZY)
+	// @JoinColumn(name = "created_by", nullable = false)
+	// private Admin createdBy;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "place_id", nullable = false)
+	private Place place;
+}

--- a/src/main/java/com/moti/backend/core/show/domain/entity/ShowSchedule.java
+++ b/src/main/java/com/moti/backend/core/show/domain/entity/ShowSchedule.java
@@ -1,0 +1,28 @@
+package com.moti.backend.core.show.domain.entity;
+
+import java.time.LocalDate;
+
+import com.moti.backend.global.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class ShowSchedule extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private LocalDate showDate;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "show_id", nullable = false)
+	private Show show;
+}

--- a/src/main/java/com/moti/backend/core/show/domain/entity/ShowSchedule.java
+++ b/src/main/java/com/moti/backend/core/show/domain/entity/ShowSchedule.java
@@ -12,8 +12,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
 
 @Entity
+@Table(name = "show_schedule")
+@Getter
 public class ShowSchedule extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/moti/backend/core/show/domain/service/ShowDomainService.java
+++ b/src/main/java/com/moti/backend/core/show/domain/service/ShowDomainService.java
@@ -1,0 +1,20 @@
+package com.moti.backend.core.show.domain.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.moti.backend.core.show.domain.entity.Show;
+import com.moti.backend.core.show.infrastructure.persistence.ShowRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ShowDomainService {
+	private final ShowRepository showRepository;
+
+	public List<Show> findAllShows() {
+		return showRepository.findAll();
+	}
+}

--- a/src/main/java/com/moti/backend/core/show/domain/type/Category.java
+++ b/src/main/java/com/moti/backend/core/show/domain/type/Category.java
@@ -1,0 +1,6 @@
+package com.moti.backend.core.show.domain.type;
+
+public enum Category {
+	MUSICAL,
+	CONCERT,
+}

--- a/src/main/java/com/moti/backend/core/show/domain/type/SeatingTier.java
+++ b/src/main/java/com/moti/backend/core/show/domain/type/SeatingTier.java
@@ -1,0 +1,8 @@
+package com.moti.backend.core.show.domain.type;
+
+public enum SeatingTier {
+	VIP,
+	R,
+	S,
+	A,
+}

--- a/src/main/java/com/moti/backend/core/show/infrastructure/persistence/ShowRepository.java
+++ b/src/main/java/com/moti/backend/core/show/infrastructure/persistence/ShowRepository.java
@@ -1,0 +1,8 @@
+package com.moti.backend.core.show.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.moti.backend.core.show.domain.entity.Show;
+
+public interface ShowRepository extends JpaRepository<Show, Long> {
+}

--- a/src/main/java/com/moti/backend/core/show/presentation/ShowController.java
+++ b/src/main/java/com/moti/backend/core/show/presentation/ShowController.java
@@ -1,0 +1,27 @@
+package com.moti.backend.core.show.presentation;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.moti.backend.core.show.application.ShowService;
+import com.moti.backend.core.show.transfer.dto.ShowResponseDTO;
+import com.moti.backend.global.dto.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/shows")
+public class ShowController {
+	private final ShowService showService;
+
+	@GetMapping
+	public ResponseEntity<ApiResponse<?>> getAllShows() {
+		ShowResponseDTO.InfoList shows = showService.getAllShows();
+		return ResponseEntity.ok(ApiResponse.success(shows));
+	}
+}

--- a/src/main/java/com/moti/backend/core/show/transfer/dto/ShowResponseDTO.java
+++ b/src/main/java/com/moti/backend/core/show/transfer/dto/ShowResponseDTO.java
@@ -1,0 +1,62 @@
+package com.moti.backend.core.show.transfer.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.moti.backend.core.show.domain.entity.Show;
+import com.moti.backend.core.show.domain.type.Category;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class ShowResponseDTO {
+	@Getter
+	@Builder
+	public static class InfoList {
+		private List<Info> shows;
+
+		public static InfoList from(List<Show> showList) {
+			List<Info> shows = showList.stream()
+				.map(Info::from)
+				.collect(Collectors.toList());
+
+			return InfoList.builder()
+				.shows(shows)
+				.build();
+		}
+	}
+
+	@Getter
+	@Builder
+	public static class Info {
+		private Long id;
+		private String title;
+		private String placeName;
+		private Category category;
+		private LocalDate startDate;
+		private LocalDate endDate;
+		private LocalDateTime ticketStartDateTime;
+		private Integer minAge;
+		private Integer runningTimeMinute;
+		private Integer intermissionTime;
+		private String imgSource;
+
+		public static Info from(Show show) {
+			return Info.builder()
+					.id(show.getId())
+					.title(show.getTitle())
+					.placeName(show.getPlace().getName())
+					.category(show.getCategory())
+					.startDate(show.getStartDate().toLocalDate())
+					.endDate(show.getEndDate().toLocalDate())
+					.ticketStartDateTime(show.getTicketStartDateTime())
+					.minAge(show.getMinAge())
+					.runningTimeMinute(show.getRunningTimeMinute())
+					.intermissionTime(show.getIntermissionTime())
+					.imgSource(show.getShowImg())
+				.build();
+		}
+	}
+}


### PR DESCRIPTION
## 연관된 이슈
> ex) #이슈번호, #이슈번호
- #12 

## 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 공연 조회 api 구현
![image](https://github.com/user-attachments/assets/4e697716-04ae-41b9-8dbb-1b2a8d59faa4)


## 테스트 결과
> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## 변경 사항 체크리스트
- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
1. 공연 포스터 이미지 경로 설정이 필요합니다. (현재는 임시용)
2. 생성자 접근제어자에 대한 부분으로 수정할 부분이 있으면 리뷰 부탁드립니다.
3. show 테이블 명도 예약어와 겹치는 상황인데 현재는 백틱으로 처리한 상태입니다.
그대로 사용할지 네이밍 수정을 할지 의견 부탁드립니다.


## 참고 자료 (선택)
> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요