### PR TITLE
[Fix] 특정 공연 정보 조회 api 수정(클라이언트 검증)

### DIFF
--- a/src/main/java/com/moti/backend/core/show/application/ShowService.java
+++ b/src/main/java/com/moti/backend/core/show/application/ShowService.java
@@ -1,5 +1,6 @@
 package com.moti.backend.core.show.application;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -25,6 +26,7 @@ public class ShowService {
 	public ShowResponseDTO.DetailInfo getShowDetail(Long showId) {
 		Show show = showDomainService.findShowById(showId);
 		List<Grade> grades = gradeDomainService.findGradesByShowId(showId);
-		return ShowResponseDTO.DetailInfo.from(show, grades);
+		LocalDateTime serverTime = LocalDateTime.now();
+		return ShowResponseDTO.DetailInfo.from(show, grades, serverTime);
 	}
 }

--- a/src/main/java/com/moti/backend/core/show/transfer/dto/ShowResponseDTO.java
+++ b/src/main/java/com/moti/backend/core/show/transfer/dto/ShowResponseDTO.java
@@ -61,9 +61,10 @@ public class ShowResponseDTO {
 		private Integer runningTimeMinute;
 		private Integer intermissionTime;
 		private String showImgUrl;
+		private LocalDateTime serverTime;
 		private List<GradeInfo> grade;
 
-		public static DetailInfo from(Show show, List<Grade> grades) {
+		public static DetailInfo from(Show show, List<Grade> grades, LocalDateTime serverTime) {
 			return DetailInfo.builder()
 				.id(show.getId())
 				.title(show.getTitle())
@@ -76,6 +77,7 @@ public class ShowResponseDTO {
 				.runningTimeMinute(show.getRunningTimeMinute())
 				.intermissionTime(show.getIntermissionTime())
 				.showImgUrl(show.getShowImgUrl())
+				.serverTime(serverTime)
 				.grade(grades.stream()
 					.map(GradeInfo::from)
 					.toList())


### PR DESCRIPTION
## 연관된 이슈
> ex) #이슈번호, #이슈번호
- #27 

## 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 클라이언트에서의 공연 인스턴스 렌더링 시, 조작 방지를 위한 서버 시간 제공
- api 응답에 serverTime을 추가하였습니다.
![image](https://github.com/user-attachments/assets/8acd6c30-ef4c-4a99-a57e-1b93e16b57a8)
