### PR TITLE
[Feat] 좌석 선택 및 예매 시 상태 변경 기능 구현

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # CODEOWNERS
-* @glaxyt @simjaesung
+* @glaxyt @simjaesung @g00hyun

--- a/src/main/java/com/moti/backend/core/reservation/application/ReservationService.java
+++ b/src/main/java/com/moti/backend/core/reservation/application/ReservationService.java
@@ -14,6 +14,7 @@ import com.moti.backend.core.reservation.infrastructure.persistence.ReservationR
 import com.moti.backend.core.reservation.infrastructure.persistence.ShowSeatMappingRepository;
 import com.moti.backend.core.reservation.transfer.CreateReservationRequest;
 import com.moti.backend.core.reservation.transfer.CreateReservationResponse;
+import com.moti.backend.core.show.application.SeatStatusService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +38,7 @@ public class ReservationService {
     private final ShowSeatLockService showSeatLockService;
     private final ShowSeatCompensationService showSeatCompensationService;
     private final ReservationCreator reservationCreator;
+    private final SeatStatusService seatStatusService;
 
     @Transactional
     public CreateReservationResponse reserve(CreateReservationRequest dto) {
@@ -49,13 +51,16 @@ public class ReservationService {
         List<ShowSeatMapping> showSeats;
 
         try {
-            // show_seat_mapping hold로 상태 변경
             showSeats = showSeatLockService.lockAndHoldShowSeats(sortedShowSeatIds);
-        } catch (Exception e) {
-            throw new SeatHoldFailedException("좌석 확보 실패");
-        }
+            Long scheduleId = showSeats.get(0).getShowSchedule().getId();
+            Long[] seatIds = showSeats.stream()
+                .map(showSeat -> showSeat.getSeat().getId())
+                .toArray(Long[]::new);
 
-        try {
+            // redis 상태 disabled로 변경 -> seatstatusservice.reserved()
+            // message도 broadcasting
+            seatStatusService.reserved(scheduleId, seatIds);
+
             Member member = memberRepository.findById(1L)
                     .orElseThrow(() -> new MemberNotFoundException("예매 시도자를 시스템에서 찾을 수 없습니다."));
 
@@ -79,6 +84,8 @@ public class ReservationService {
 
             return new CreateReservationResponse(orderToken, totalAmount, sortedShowSeatIds);
 
+        } catch (SeatHoldFailedException e) {
+            throw new SeatHoldFailedException("좌석 확보 실패");
         } catch (Exception e) {
             // 예외 발생 시 보상 로직 실행
             // 새롭게 생성된 트랜잭션의 결과인 좌석 상태 복구

--- a/src/main/java/com/moti/backend/core/show/application/SeatStatusService.java
+++ b/src/main/java/com/moti/backend/core/show/application/SeatStatusService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import com.moti.backend.core.place.infrastructure.persistence.SeatRepository;
 import com.moti.backend.core.show.infrastructure.cache.SeatCacheRepository;
 import com.moti.backend.core.show.presentation.socket.EventType;
+import com.moti.backend.core.show.presentation.socket.SeatPublisher;
 import com.moti.backend.core.show.presentation.socket.SeatStatus;
 import com.moti.backend.core.show.presentation.socket.dto.SeatResponseDTO.SeatToggleResponse;
 
@@ -18,6 +19,7 @@ public class SeatStatusService {
 
 	private final SeatRepository seatRepository;
 	private final SeatCacheRepository seatCacheRepository;
+	private final SeatPublisher seatPublisher;
 
 	public SeatToggleResponse selected(Long showScheduleId, Long seatId) {
 		// memberId를 사용하여 좌석을 선택한 사용자를 추적해야합니다.
@@ -33,22 +35,21 @@ public class SeatStatusService {
 		);
 	}
 
-	// public SeatToggleResponse disSelected(Long showScheduleId, Long seatId, Long memberId) {
-	// 	seatCacheRepository.disSelected(showScheduleId, seatId, Long memberId);
-	//
-	// 	return SeatToggleResponse.from(
-	// 		EventType.SEAT_SELECTED,// redis를 해당 좌석이 선택중인지 아닌지 확인 필요
-	// 		showScheduleId,
-	// 		seatId,
-	// 		SeatStatus.SELECTED,
-	// 		1,  // redis를 통해 조회한 선택된 좌석의 개수 추가 필요
-	// 		LocalDateTime.now()
-	// 	);
-	// }
-	//
-	// public SeatReservationResponse reserved(Long showScheduleId, SeatRequestDTO.SeatReservationRequest request) {
-	// 	seatCacheRepository.reserved(showScheduleId, seatId);
-	// 	return new SeatReservationResponse(seatId, "RESERVED");
-	//
-	// }
+	public SeatToggleResponse deselected(Long showScheduleId, Long seatId) {
+		seatCacheRepository.deselected(showScheduleId, seatId);
+
+		return SeatToggleResponse.from(
+			EventType.SEAT_DESELECTED,// redis를 해당 좌석이 선택중인지 아닌지 확인 필요
+			showScheduleId,
+			seatId,
+			SeatStatus.AVAILABLE,
+			0,  // redis를 통해 조회한 선택된 좌석의 개수 추가 필요
+			LocalDateTime.now()
+		);
+	}
+
+	public void reserved(Long showScheduleId, Long[] seatIds) {
+		seatCacheRepository.reserved(showScheduleId, seatIds);
+		seatPublisher.pubMessageByScheduleId(showScheduleId, seatIds);
+	}
 }

--- a/src/main/java/com/moti/backend/core/show/infrastructure/cache/SeatCacheRepository.java
+++ b/src/main/java/com/moti/backend/core/show/infrastructure/cache/SeatCacheRepository.java
@@ -1,5 +1,7 @@
 package com.moti.backend.core.show.infrastructure.cache;
 
+import java.time.Duration;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -14,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SeatCacheRepository {
 
+	private final RedisTemplate<String, String> redisTemplate;
 	// Redis의 Hash 자료구조를 다루기 위한 인터페이스
 	private final HashOperations<String, String, String> hashOps;
 	// Redis의 Set 자료구조를 다루기 위한 인터페이스
@@ -23,18 +26,13 @@ public class SeatCacheRepository {
 	// 여기서는 설명을 위해 간단한 String 템플릿을 사용한다고 가정합니다.
 	@Autowired
 	public SeatCacheRepository(RedisTemplate<String, String> redisTemplate) {
+		this.redisTemplate = redisTemplate;
 		this.hashOps = redisTemplate.opsForHash();
 		this.setOps = redisTemplate.opsForSet();
 	}
 
 	private static final String SEAT_STATUS_KEY = "seat:%d:status";
 	private static final String HOLD_SEAT_KEY = "hold:%d:%d";
-	private static final String HOLD_SCHEDULE_KEY = "hold:%d";
-
-	// public void selected(Long showScheduleId, Long seatId) {
-	// 	String key = String.format(SEAT_STATUS_KEY, showScheduleId, seatId);
-	// 	redisTemplate.opsForValue().set(key, SeatStatus.SELECTED);
-	// }
 
 	public void select(Long showScheduleId, Long seatId) {
 		String statusKey = String.format(SEAT_STATUS_KEY, showScheduleId);
@@ -44,8 +42,24 @@ public class SeatCacheRepository {
 		hashOps.put(statusKey, seatIdStr, String.valueOf(SeatStatus.SELECTED));
 	}
 
-	// public void disSelected(Long showScheduleId, Long seatId) {
-	// 	String key = String.format(SEAT_STATUS_KEY, showScheduleId, seatId);
-	// 	redisTemplate.opsForValue().set(key, SeatStatus.SELECTED);
-	// }
+	public void deselected(Long showScheduleId, Long seatId) {
+		String statusKey = String.format(SEAT_STATUS_KEY, showScheduleId);
+		String seatIdStr = String.valueOf(seatId);
+
+		// 1. Hash에 좌석 상태를 'AVAILABLE'로 업데이트
+		hashOps.put(statusKey, seatIdStr, String.valueOf(SeatStatus.AVAILABLE));
+	}
+
+	public void reserved(Long showScheduleId, Long[] seatIds) {
+		String statusKey = String.format(SEAT_STATUS_KEY, showScheduleId);
+
+		for (Long seatId : seatIds) {
+			// 1. Hash에 좌석 상태를 'DISABLED'로 업데이트
+			hashOps.put(statusKey, String.valueOf(seatId), String.valueOf(SeatStatus.DISABLED));
+
+			// 2. HOLD TTL 상태 업데이트
+			String holdKey = String.format(HOLD_SEAT_KEY, showScheduleId, seatId);
+			redisTemplate.opsForValue().set(holdKey, "HELD", Duration.ofMinutes(10));
+		}
+	}
 }

--- a/src/main/java/com/moti/backend/core/show/presentation/socket/EventType.java
+++ b/src/main/java/com/moti/backend/core/show/presentation/socket/EventType.java
@@ -5,6 +5,7 @@ public enum EventType {
 	SEAT_RESERVED,
 	SEAT_SELECTED,
 	SEAT_DESELECTED,
+	SEAT_DISABLED,
 	//todo: error 이벤트 타입은 분류해야할지?
 	SEAT_SELECT_ERROR,
 	SEAT_LIMIT_ERROR,

--- a/src/main/java/com/moti/backend/core/show/presentation/socket/SeatGateway.java
+++ b/src/main/java/com/moti/backend/core/show/presentation/socket/SeatGateway.java
@@ -22,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class SeatGateway {
 
-	private final SeatStatusService showSocketService;
+	private final SeatStatusService showStatusService;
 	private final SimpMessagingTemplate messagingTemplate;
 
 	@MessageMapping("/seat/select")
@@ -36,7 +36,7 @@ public class SeatGateway {
 		// );
 		log.info("selectSeat request: {}", request);
 
-		SeatToggleResponse response = showSocketService.selected(
+		SeatToggleResponse response = showStatusService.selected(
 			request.getShowScheduleId(),
 			request.getSeatId()
 		);
@@ -45,32 +45,18 @@ public class SeatGateway {
 		messagingTemplate.convertAndSend(destination, response);
 	}
 
-	// @MessageMapping("/seat/deselect")
-	// public void deselectSeat(SeatToggleRequest request, Principal principal) {
-	//
-	// 	SeatToggleResponse response = showSocketService.disSelected(
-	// 		request.getShowScheduleId(),
-	// 		request.getSeatId(),
-	// 		getMemberIdFromPrincipal(principal)
-	// 	);
-	//
-	// 	String destination = "/topic/show-schedule/" + request.getShowScheduleId() + "/seats";
-	// 	messagingTemplate.convertAndSend(destination, response);
-	// }
+	@MessageMapping("/seat/deselect")
+	public void deselectSeat(SeatToggleRequest request) {
+		// , Principal principal
+		SeatToggleResponse response = showStatusService.deselected(
+			request.getShowScheduleId(),
+			request.getSeatId()
+			// getMemberIdFromPrincipal(principal)
+		);
 
-	// @MessageMapping("/seat/reserve")
-	// public SeatReservationResponse reserveSeat(
-	// 	// 3. @MessageMapping 경로의 {showId} 변수를 파라미터로 가져옵니다.
-	// 	@DestinationVariable String show_schedule_id,
-	// 	// 4. 클라이언트가 보낸 JSON 데이터를 자바 객체로 변환하여 받습니다.
-	// 	SeatReservationRequest request) {
-	//
-	// 	// 5. 서비스 계층을 호출하여 비즈니스 로직을 수행합니다.
-	// 	SeatReservationResponse changedStatus = showSocketService.reserved(show_schedule_id, request.getSeatId());
-	//
-	// 	// 6. 반환된 객체가 @SendTo에 지정된 토픽으로 전송됩니다.
-	// 	return changedStatus;
-	// }
+		String destination = "/topic/show-schedule/" + request.getShowScheduleId() + "/seats";
+		messagingTemplate.convertAndSend(destination, response);
+	}
 
 	//todo: GateWay에서 시큐리티 컨텍스트에서 직접 접근하여 member 정보를 가져오는게 적합한지 확인 필요
 	private Long getMemberIdFromPrincipal(Principal principal) {

--- a/src/main/java/com/moti/backend/core/show/presentation/socket/SeatGateway.java
+++ b/src/main/java/com/moti/backend/core/show/presentation/socket/SeatGateway.java
@@ -53,6 +53,9 @@ public class SeatGateway {
 			request.getSeatId()
 			// getMemberIdFromPrincipal(principal)
 		);
+
+		String destination = "/topic/show-schedule/" + request.getShowScheduleId() + "/seats";
+		messagingTemplate.convertAndSend(destination, response);
 	}
 
 	//todo: GateWay에서 시큐리티 컨텍스트에서 직접 접근하여 member 정보를 가져오는게 적합한지 확인 필요

--- a/src/main/java/com/moti/backend/core/show/presentation/socket/SeatGateway.java
+++ b/src/main/java/com/moti/backend/core/show/presentation/socket/SeatGateway.java
@@ -22,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class SeatGateway {
 
-	private final SeatStatusService showSocketService;
+	private final SeatStatusService showStatusService;
 	private final SimpMessagingTemplate messagingTemplate;
 
 	@MessageMapping("/seat/select")
@@ -36,7 +36,7 @@ public class SeatGateway {
 		// );
 		log.info("selectSeat request: {}", request);
 
-		SeatToggleResponse response = showSocketService.selected(
+		SeatToggleResponse response = showStatusService.selected(
 			request.getShowScheduleId(),
 			request.getSeatId()
 		);
@@ -45,32 +45,15 @@ public class SeatGateway {
 		messagingTemplate.convertAndSend(destination, response);
 	}
 
-	// @MessageMapping("/seat/deselect")
-	// public void deselectSeat(SeatToggleRequest request, Principal principal) {
-	//
-	// 	SeatToggleResponse response = showSocketService.disSelected(
-	// 		request.getShowScheduleId(),
-	// 		request.getSeatId(),
-	// 		getMemberIdFromPrincipal(principal)
-	// 	);
-	//
-	// 	String destination = "/topic/show-schedule/" + request.getShowScheduleId() + "/seats";
-	// 	messagingTemplate.convertAndSend(destination, response);
-	// }
-
-	// @MessageMapping("/seat/reserve")
-	// public SeatReservationResponse reserveSeat(
-	// 	// 3. @MessageMapping 경로의 {showId} 변수를 파라미터로 가져옵니다.
-	// 	@DestinationVariable String show_schedule_id,
-	// 	// 4. 클라이언트가 보낸 JSON 데이터를 자바 객체로 변환하여 받습니다.
-	// 	SeatReservationRequest request) {
-	//
-	// 	// 5. 서비스 계층을 호출하여 비즈니스 로직을 수행합니다.
-	// 	SeatReservationResponse changedStatus = showSocketService.reserved(show_schedule_id, request.getSeatId());
-	//
-	// 	// 6. 반환된 객체가 @SendTo에 지정된 토픽으로 전송됩니다.
-	// 	return changedStatus;
-	// }
+	@MessageMapping("/seat/deselect")
+	public void deselectSeat(SeatToggleRequest request) {
+		// , Principal principal
+		SeatToggleResponse response = showStatusService.deselected(
+			request.getShowScheduleId(),
+			request.getSeatId()
+			// getMemberIdFromPrincipal(principal)
+		);
+	}
 
 	//todo: GateWay에서 시큐리티 컨텍스트에서 직접 접근하여 member 정보를 가져오는게 적합한지 확인 필요
 	private Long getMemberIdFromPrincipal(Principal principal) {

--- a/src/main/java/com/moti/backend/core/show/presentation/socket/SeatPublisher.java
+++ b/src/main/java/com/moti/backend/core/show/presentation/socket/SeatPublisher.java
@@ -1,0 +1,31 @@
+package com.moti.backend.core.show.presentation.socket;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import static com.moti.backend.core.show.presentation.socket.dto.SeatResponseDTO.*;
+
+import java.time.LocalDateTime;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SeatPublisher {
+	private final SimpMessagingTemplate messagingTemplate;
+	private static final Long TTL_SECONDS = 600L;
+
+	public void pubMessageByScheduleId(Long showScheduleId, Long[] seatIds) {
+
+		SeatReservationResponse response = SeatReservationResponse.from(
+			EventType.SEAT_DESELECTED,// redis를 해당 좌석이 선택중인지 아닌지 확인 필요
+			showScheduleId,
+			seatIds,
+			TTL_SECONDS,
+ 			LocalDateTime.now()
+		);
+
+		String destination = "/topic/show-schedule/" + showScheduleId + "/seats";
+		messagingTemplate.convertAndSend(destination, response);
+	}
+}

--- a/src/main/java/com/moti/backend/core/show/presentation/socket/SeatPublisher.java
+++ b/src/main/java/com/moti/backend/core/show/presentation/socket/SeatPublisher.java
@@ -18,7 +18,7 @@ public class SeatPublisher {
 	public void pubMessageByScheduleId(Long showScheduleId, Long[] seatIds) {
 
 		SeatReservationResponse response = SeatReservationResponse.from(
-			EventType.SEAT_DESELECTED,// redis를 해당 좌석이 선택중인지 아닌지 확인 필요
+			EventType.SEAT_DISABLED,// redis를 해당 좌석이 선택중인지 아닌지 확인 필요
 			showScheduleId,
 			seatIds,
 			TTL_SECONDS,

--- a/src/main/java/com/moti/backend/core/show/presentation/socket/dto/SeatResponseDTO.java
+++ b/src/main/java/com/moti/backend/core/show/presentation/socket/dto/SeatResponseDTO.java
@@ -40,15 +40,18 @@ public class SeatResponseDTO {
 		private EventType eventType;
 		private Long showScheduleId;
 		private Long[] seatIds;
-		private int ttlSeconds;
-		private String timestamp;
+		private SeatStatus seatStatus;
+		private long ttlSeconds;
+		private LocalDateTime timestamp;
+
 
 		public static SeatReservationResponse from(EventType eventType, Long showScheduleId, Long[] seatIds,
-			int ttlSeconds, String timestamp) {
+			long ttlSeconds, LocalDateTime timestamp) {
 			return SeatReservationResponse.builder()
 				.eventType(eventType)
 				.showScheduleId(showScheduleId)
 				.seatIds(seatIds)
+				.seatStatus(SeatStatus.DISABLED)
 				.ttlSeconds(ttlSeconds)
 				.timestamp(timestamp)
 				.build();
@@ -61,10 +64,10 @@ public class SeatResponseDTO {
 		private EventType eventType;
 		private Long showScheduleId;
 		private List<SeatInfo> seatIds;
-		private String timestamp;
+		private LocalDateTime timestamp;
 
 		public static InitialSeatResponse from(EventType eventType, Long showScheduleId, List<SeatInfo> seatInfoList,
-			String timestamp) {
+			LocalDateTime timestamp) {
 			return InitialSeatResponse.builder()
 				.eventType(eventType)
 				.showScheduleId(showScheduleId)


### PR DESCRIPTION
## 연관된 이슈
- #32 

## 작업 내용
- 페어프로그래밍: 광현, 성현
- 좌석 선택 '/app/seat/select' 기능 구현
- 좌석 선택 해제 '/app/seat/deselect' 기능 구현
- 예매하기 HTTP API를 통한 브로드 캐스팅 기능 구현
  - SeatPublisher.java 구현: 서버 -> 클라이언트에게 메세지를 전달하는 용도의 클래스

### 변경사항(필독 바람)
- 본래 소켓 API 스펙으로 좌석 예약이 존재했으나, 예매하기 API의 단일 책임으로 수행하는 것이 복잡성을 해소할 것이라 판단했습니다.
- 기존 '/app/seat/reserve' 는 deprecated 됨 
- 기존 좌석 예매하기 API 호출 시 구독한 전체 인원에게 브로드 캐스팅되게 구현했습니다.

## 테스트 결과
### 예매하기 API 호출 시
<img width="850" height="710" alt="image" src="https://github.com/user-attachments/assets/333fd065-3ae0-4f7d-ac73-3d2a7ad376d5" />

### 레디스에 정상적으로 데이터 변경 확인
<img width="365" height="60" alt="image" src="https://github.com/user-attachments/assets/af747afe-1a18-42ee-aa0f-a5883fcc4506" />
<img width="210" height="29" alt="image" src="https://github.com/user-attachments/assets/d135c8d8-3393-45ce-821d-4acf8902035f" />


### 구독한 클라이언트에게 브로드캐스팅 확인
- 아래 이미지에 있는 SEAT_DESELECTED 이벤트 타입은 SEAT_DISABLED로 변경했으니 참고 바람
<img width="952" height="296" alt="image" src="https://github.com/user-attachments/assets/f29e7425-f3f9-49bd-b7bd-031b6254e9ba" />


## 변경 사항 체크리스트
- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 참고 자료 (선택)
> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요