### PR TITLE
[Feat] WebSocket 연결에 인증정보 추가

### DIFF
--- a/src/main/java/com/moti/backend/config/WebSocketConfig.java
+++ b/src/main/java/com/moti/backend/config/WebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.moti.backend.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -28,8 +29,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 		registry.addEndpoint("/ws").setAllowedOrigins("*");
 	}
 
-	// @Override
-	// public void configureClientInboundChannel(ChannelRegistration registration) {
-	// 	registration.interceptors(webSocketAuthInterceptor);
-	// }
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(webSocketAuthInterceptor);
+	}
 }

--- a/src/main/java/com/moti/backend/core/show/application/SeatStatusService.java
+++ b/src/main/java/com/moti/backend/core/show/application/SeatStatusService.java
@@ -5,10 +5,10 @@ import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 
 import com.moti.backend.core.place.infrastructure.persistence.SeatRepository;
+import com.moti.backend.core.show.domain.type.EventType;
+import com.moti.backend.core.show.domain.type.SeatStatus;
 import com.moti.backend.core.show.infrastructure.cache.SeatCacheRepository;
-import com.moti.backend.core.show.presentation.socket.EventType;
 import com.moti.backend.core.show.presentation.socket.SeatPublisher;
-import com.moti.backend.core.show.presentation.socket.SeatStatus;
 import com.moti.backend.core.show.presentation.socket.dto.SeatResponseDTO.SeatToggleResponse;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/moti/backend/core/show/domain/type/EventType.java
+++ b/src/main/java/com/moti/backend/core/show/domain/type/EventType.java
@@ -1,4 +1,4 @@
-package com.moti.backend.core.show.presentation.socket;
+package com.moti.backend.core.show.domain.type;
 
 public enum EventType {
 	INITIAL_SEAT_STATUS,

--- a/src/main/java/com/moti/backend/core/show/domain/type/SeatStatus.java
+++ b/src/main/java/com/moti/backend/core/show/domain/type/SeatStatus.java
@@ -1,4 +1,4 @@
-package com.moti.backend.core.show.presentation.socket;
+package com.moti.backend.core.show.domain.type;
 
 public enum SeatStatus {
 	AVAILABLE,

--- a/src/main/java/com/moti/backend/core/show/infrastructure/cache/SeatCacheRepository.java
+++ b/src/main/java/com/moti/backend/core/show/infrastructure/cache/SeatCacheRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Repository;
 
-import com.moti.backend.core.show.presentation.socket.SeatStatus;
+import com.moti.backend.core.show.domain.type.SeatStatus;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/moti/backend/core/show/presentation/socket/SeatGateway.java
+++ b/src/main/java/com/moti/backend/core/show/presentation/socket/SeatGateway.java
@@ -2,11 +2,9 @@ package com.moti.backend.core.show.presentation.socket;
 
 import static com.moti.backend.core.show.presentation.socket.dto.SeatRequestDTO.*;
 
-import java.security.Principal;
-
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Controller;
 
 import com.moti.backend.core.member.domain.entity.Member;
@@ -26,15 +24,8 @@ public class SeatGateway {
 	private final SimpMessagingTemplate messagingTemplate;
 
 	@MessageMapping("/seat/select")
-	public void selectSeat(SeatToggleRequest request) {
-
-		// Principal principal
-		// SeatToggleResponse response = showSocketService.selected(
-		// 	request.getShowScheduleId(),
-		// 	request.getSeatId(),
-		// 	getMemberIdFromPrincipal(principal)
-		// );
-		log.info("selectSeat request: {}", request);
+	public void selectSeat(SeatToggleRequest request, StompHeaderAccessor accessor) {
+		Long memberId = getMemberIdFromStompHeaderAccessor(accessor);
 
 		SeatToggleResponse response = showStatusService.selected(
 			request.getShowScheduleId(),
@@ -46,27 +37,24 @@ public class SeatGateway {
 	}
 
 	@MessageMapping("/seat/deselect")
-	public void deselectSeat(SeatToggleRequest request) {
-		// , Principal principal
+	public void deselectSeat(SeatToggleRequest request, StompHeaderAccessor accessor) {
+		Long memberId = getMemberIdFromStompHeaderAccessor(accessor);
+
 		SeatToggleResponse response = showStatusService.deselected(
 			request.getShowScheduleId(),
 			request.getSeatId()
-			// getMemberIdFromPrincipal(principal)
 		);
 
 		String destination = "/topic/show-schedule/" + request.getShowScheduleId() + "/seats";
 		messagingTemplate.convertAndSend(destination, response);
 	}
 
-	//todo: GateWay에서 시큐리티 컨텍스트에서 직접 접근하여 member 정보를 가져오는게 적합한지 확인 필요
-	private Long getMemberIdFromPrincipal(Principal principal) {
-		if (principal instanceof UsernamePasswordAuthenticationToken) {
-			Object principalObj = ((UsernamePasswordAuthenticationToken)principal).getPrincipal();
-			if (principalObj instanceof Member) {
-				return ((Member)principalObj).getId();
-			}
+	private Long getMemberIdFromStompHeaderAccessor(StompHeaderAccessor accessor) {
+		Member member = (Member)accessor.getSessionAttributes().get("user");
+		if (member == null) {
+			log.error("WebSocket 세션에 사용자 정보가 없습니다. 세션: {}", accessor.getSessionId());
+			throw new JwtAuthenticationException("사용자 정보가 세션에 없습니다.");
 		}
-		throw new JwtAuthenticationException("인증 정보에서 memberId를 찾을 수 없습니다.");
+		return member.getId();
 	}
-
 }

--- a/src/main/java/com/moti/backend/core/show/presentation/socket/SeatPublisher.java
+++ b/src/main/java/com/moti/backend/core/show/presentation/socket/SeatPublisher.java
@@ -1,11 +1,13 @@
 package com.moti.backend.core.show.presentation.socket;
 
-import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.stereotype.Component;
-
 import static com.moti.backend.core.show.presentation.socket.dto.SeatResponseDTO.*;
 
 import java.time.LocalDateTime;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import com.moti.backend.core.show.domain.type.EventType;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,7 +24,7 @@ public class SeatPublisher {
 			showScheduleId,
 			seatIds,
 			TTL_SECONDS,
- 			LocalDateTime.now()
+			LocalDateTime.now()
 		);
 
 		String destination = "/topic/show-schedule/" + showScheduleId + "/seats";

--- a/src/main/java/com/moti/backend/core/show/presentation/socket/dto/SeatResponseDTO.java
+++ b/src/main/java/com/moti/backend/core/show/presentation/socket/dto/SeatResponseDTO.java
@@ -3,8 +3,8 @@ package com.moti.backend.core.show.presentation.socket.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.moti.backend.core.show.presentation.socket.EventType;
-import com.moti.backend.core.show.presentation.socket.SeatStatus;
+import com.moti.backend.core.show.domain.type.EventType;
+import com.moti.backend.core.show.domain.type.SeatStatus;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -43,7 +43,6 @@ public class SeatResponseDTO {
 		private SeatStatus seatStatus;
 		private long ttlSeconds;
 		private LocalDateTime timestamp;
-
 
 		public static SeatReservationResponse from(EventType eventType, Long showScheduleId, Long[] seatIds,
 			long ttlSeconds, LocalDateTime timestamp) {

--- a/src/main/java/com/moti/backend/global/security/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/moti/backend/global/security/WebSocketAuthInterceptor.java
@@ -1,7 +1,5 @@
 package com.moti.backend.global.security;
 
-import java.security.Principal;
-import java.util.Collections;
 import java.util.List;
 
 import org.springframework.messaging.Message;
@@ -9,7 +7,6 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
 
 import com.moti.backend.core.member.domain.entity.Member;
@@ -37,21 +34,16 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
 			return authenticateUser(accessor, message);
 		}
 
-		// CONNECT 이후 모든 메시지에서 인증 상태 확인
-		if (requiresAuthentication(accessor.getCommand())) {
-			return validateAuthenticatedUser(accessor, message);
-		}
-
 		return message;
 	}
 
 	private Message<?> authenticateUser(StompHeaderAccessor accessor, Message<?> message) {
 		try {
-			// Authorization 헤더에서 JWT 토큰 추출
 			String token = extractTokenFromHeader(accessor);
+			log.info("WebSocket CONNECT 요청 - 세션: {}", accessor.getSessionId());
 
-			// JWT 토큰 검증
 			if (!jwtTokenProvider.validateToken(token)) {
+				log.warn("유효하지 않은 토큰으로 CONNECT 시도 - 세션: {}", accessor.getSessionId());
 				throw new JwtAuthenticationException("유효하지 않은 토큰입니다.");
 			}
 
@@ -59,42 +51,13 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
 			Member member = memberRepository.findById(memberId)
 				.orElseThrow(() -> new MemberNotFoundException("사용자를 찾을 수 없습니다."));
 
-			// STOMP 세션에 사용자 정보 설정
-			UsernamePasswordAuthenticationToken authentication =
-				new UsernamePasswordAuthenticationToken(member, null, Collections.emptyList());
-
-			accessor.setUser(authentication);
-
+			// WebSocket 세션에 저장
+			accessor.getSessionAttributes().put("user", member);
 			return message;
-
 		} catch (Exception e) {
-			// 인증 실패 시 null 반환 (연결 차단)
+			log.error("WebSocket 인증 실패 - 세션: {}, 오류: {}", accessor.getSessionId(), e.getMessage());
 			return null;
 		}
-	}
-
-	private Message<?> validateAuthenticatedUser(StompHeaderAccessor accessor, Message<?> message) {
-		Principal user = accessor.getUser();
-
-		if (user == null) {
-			log.warn("인증되지 않은 사용자의 메시지 시도 - command: {}", accessor.getCommand());
-			return null; // 메시지 차단
-		}
-
-		// 추가 검증 로직 (필요시)
-		String memberId = (String)accessor.getSessionAttributes().get("memberId");
-		if (memberId == null) {
-			log.warn("세션에 memberId가 없음");
-			return null;
-		}
-
-		return message;
-	}
-
-	private boolean requiresAuthentication(StompCommand command) {
-		return command == StompCommand.SUBSCRIBE ||
-			command == StompCommand.SEND ||
-			command == StompCommand.MESSAGE;
 	}
 
 	private String extractTokenFromHeader(StompHeaderAccessor accessor) {


### PR DESCRIPTION
## 연관된 이슈
> #34 

## 작업 내용
- WebSocketAuthInterceptor를 추가하여 STOMP CONNECT 시 JWT 인증을 처리
- 인증 통과 시 WebSocket 세션 attribute에 Member 정보 저장
- SeatGateway 컨트롤러에서 세션에서 회원 정보 조회하여 비즈니스 로직 처리하도록 수정
- WebSocketConfig 인터셉터 등록 및 관련 설정 반영


## 테스트 결과
게이트웨이 레벨에서 WebSocket 세션에 접근하여 회원정보에 접근한 로그입니다.

<img width="1456" height="108" alt="image" src="https://github.com/user-attachments/assets/50ece7a7-2d31-4b2b-b7f3-e43a9da1ca83" />


## 변경 사항 체크리스트
- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 참고 자료 (선택)
해당 기능은 최대한 간단하게 구현한 것이며, 추후 멀티서버 등 확장 시 더 견고한 로직으로 수정이 필요합니다.